### PR TITLE
repo_overrides

### DIFF
--- a/helm-charts/dih/charts/grafana/values.yaml
+++ b/helm-charts/dih/charts/grafana/values.yaml
@@ -1,0 +1,1140 @@
+rbac:
+  create: true
+  ## Use an existing ClusterRole/Role (depending on rbac.namespaced false/true)
+  # useExistingRole: name-of-some-(cluster)role
+  pspEnabled: true
+  pspUseAppArmor: true
+  namespaced: false
+  extraRoleRules: []
+  # - apiGroups: []
+  #   resources: []
+  #   verbs: []
+  extraClusterRoleRules: []
+  # - apiGroups: []
+  #   resources: []
+  #   verbs: []
+serviceAccount:
+  create: true
+  name:
+  nameTest:
+  ## ServiceAccount labels.
+  labels: {}
+## Service account annotations. Can be templated.
+#  annotations:
+#    eks.amazonaws.com/role-arn: arn:aws:iam::123456789000:role/iam-role-name-here
+  autoMount: true
+
+replicas: 1
+
+## Create a headless service for the deployment
+headlessService: false
+
+## Create HorizontalPodAutoscaler object for deployment type
+#
+autoscaling:
+  enabled: false
+#   minReplicas: 1
+#   maxReplicas: 10
+#   metrics:
+#   - type: Resource
+#     resource:
+#       name: cpu
+#       targetAverageUtilization: 60
+#   - type: Resource
+#     resource:
+#       name: memory
+#       targetAverageUtilization: 60
+
+## See `kubectl explain poddisruptionbudget.spec` for more
+## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+podDisruptionBudget: {}
+#  minAvailable: 1
+#  maxUnavailable: 1
+
+## See `kubectl explain deployment.spec.strategy` for more
+## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+deploymentStrategy:
+  type: RollingUpdate
+
+readinessProbe:
+  httpGet:
+    path: /api/health
+    port: 3000
+
+livenessProbe:
+  httpGet:
+    path: /api/health
+    port: 3000
+  initialDelaySeconds: 60
+  timeoutSeconds: 30
+  failureThreshold: 10
+
+## Use an alternate scheduler, e.g. "stork".
+## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+##
+# schedulerName: "default-scheduler"
+
+image:
+  repository: grafana/grafana
+  # Overrides the Grafana image tag whose default is the chart appVersion
+  tag: ""
+  sha: ""
+  pullPolicy: IfNotPresent
+
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ## Can be templated.
+  ##
+  pullSecrets:
+
+testFramework:
+  enabled: true
+  image: "bats/bats"
+  tag: "v1.4.1"
+  imagePullPolicy: IfNotPresent
+  securityContext: {}
+
+securityContext: {}
+#  runAsUser: 472
+#  runAsGroup: 472
+#  fsGroup: 472
+
+containerSecurityContext: {}
+
+# Enable creating the grafana configmap
+createConfigmap: true
+
+# Extra configmaps to mount in grafana pods
+# Values are templated.
+extraConfigmapMounts: []
+  # - name: certs-configmap
+  #   mountPath: /etc/grafana/ssl/
+  #   subPath: certificates.crt # (optional)
+  #   configMap: certs-configmap
+  #   readOnly: true
+
+
+extraEmptyDirMounts: []
+  # - name: provisioning-notifiers
+  #   mountPath: /etc/grafana/provisioning/notifiers
+
+
+# Apply extra labels to common labels.
+extraLabels: {}
+
+## Assign a PriorityClassName to pods if set
+# priorityClassName:
+
+downloadDashboardsImage:
+  repository: curlimages/curl
+  tag: 7.85.0
+  sha: ""
+  pullPolicy: IfNotPresent
+
+downloadDashboards:
+  env: {}
+  envFromSecret: ""
+  resources: {}
+  securityContext: {}
+
+## Pod Annotations
+# podAnnotations: {}
+
+## Pod Labels
+# podLabels: {}
+
+podPortName: grafana
+
+## Deployment annotations
+# annotations: {}
+
+## Expose the grafana service to be accessed from outside the cluster (LoadBalancer service).
+## or access it from within the cluster (ClusterIP service). Set the service type and the port to serve it.
+## ref: http://kubernetes.io/docs/user-guide/services/
+##
+service:
+  enabled: true
+  type: ClusterIP
+  port: 80
+  targetPort: 3000
+    # targetPort: 4181 To be used with a proxy extraContainer
+  ## Service annotations. Can be templated.
+  annotations: {}
+  labels: {}
+  portName: service
+  # Adds the appProtocol field to the service. This allows to work with istio protocol selection. Ex: "http" or "tcp"
+  appProtocol: ""
+
+serviceMonitor:
+  ## If true, a ServiceMonitor CRD is created for a prometheus operator
+  ## https://github.com/coreos/prometheus-operator
+  ##
+  enabled: false
+  path: /metrics
+  #  namespace: monitoring  (defaults to use the namespace this chart is deployed to)
+  labels: {}
+  interval: 1m
+  scheme: http
+  tlsConfig: {}
+  scrapeTimeout: 30s
+  relabelings: []
+
+extraExposePorts: []
+ # - name: keycloak
+ #   port: 8080
+ #   targetPort: 8080
+ #   type: ClusterIP
+
+# overrides pod.spec.hostAliases in the grafana deployment's pods
+hostAliases: []
+  # - ip: "1.2.3.4"
+  #   hostnames:
+  #     - "my.host.com"
+
+ingress:
+  enabled: false
+  # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
+  # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
+  # ingressClassName: nginx
+  # Values can be templated
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  labels: {}
+  path: /
+
+  # pathType is only for k8s >= 1.1=
+  pathType: Prefix
+
+  hosts:
+    - chart-example.local
+  ## Extra paths to prepend to every host configuration. This is useful when working with annotation based services.
+  extraPaths: []
+  # - path: /*
+  #   backend:
+  #     serviceName: ssl-redirect
+  #     servicePort: use-annotation
+  ## Or for k8s > 1.19
+  # - path: /*
+  #   pathType: Prefix
+  #   backend:
+  #     service:
+  #       name: ssl-redirect
+  #       port:
+  #         name: use-annotation
+
+
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+#  limits:
+#    cpu: 100m
+#    memory: 128Mi
+#  requests:
+#    cpu: 100m
+#    memory: 128Mi
+
+## Node labels for pod assignment
+## ref: https://kubernetes.io/docs/user-guide/node-selection/
+#
+nodeSelector: {}
+
+## Tolerations for pod assignment
+## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+##
+tolerations: []
+
+## Affinity for pod assignment (evaluated as template)
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+##
+affinity: {}
+
+## Topology Spread Constraints
+## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+##
+topologySpreadConstraints: []
+
+## Additional init containers (evaluated as template)
+## ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+##
+extraInitContainers: []
+
+## Enable an Specify container in extraContainers. This is meant to allow adding an authentication proxy to a grafana pod
+extraContainers: ""
+# extraContainers: |
+# - name: proxy
+#   image: quay.io/gambol99/keycloak-proxy:latest
+#   args:
+#   - -provider=github
+#   - -client-id=
+#   - -client-secret=
+#   - -github-org=<ORG_NAME>
+#   - -email-domain=*
+#   - -cookie-secret=
+#   - -http-address=http://0.0.0.0:4181
+#   - -upstream-url=http://127.0.0.1:3000
+#   ports:
+#     - name: proxy-web
+#       containerPort: 4181
+
+## Volumes that can be used in init containers that will not be mounted to deployment pods
+extraContainerVolumes: []
+#  - name: volume-from-secret
+#    secret:
+#      secretName: secret-to-mount
+#  - name: empty-dir-volume
+#    emptyDir: {}
+
+## Enable persistence using Persistent Volume Claims
+## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+##
+persistence:
+  type: pvc
+  enabled: false
+  # storageClassName: default
+  accessModes:
+    - ReadWriteOnce
+  size: 10Gi
+  # annotations: {}
+  finalizers:
+    - kubernetes.io/pvc-protection
+  # selectorLabels: {}
+  ## Sub-directory of the PV to mount. Can be templated.
+  # subPath: ""
+  ## Name of an existing PVC. Can be templated.
+  # existingClaim:
+  ## Extra labels to apply to a PVC.
+  extraPvcLabels: {}
+
+  ## If persistence is not enabled, this allows to mount the
+  ## local storage in-memory to improve performance
+  ##
+  inMemory:
+    enabled: false
+    ## The maximum usage on memory medium EmptyDir would be
+    ## the minimum value between the SizeLimit specified
+    ## here and the sum of memory limits of all containers in a pod
+    ##
+    # sizeLimit: 300Mi
+
+initChownData:
+  ## If false, data ownership will not be reset at startup
+  ## This allows the grafana-server to be run with an arbitrary user
+  ##
+  enabled: true
+
+  ## initChownData container image
+  ##
+  image:
+    repository: busybox
+    tag: "1.31.1"
+    sha: ""
+    pullPolicy: IfNotPresent
+
+  ## initChownData resource requests and limits
+  ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources: {}
+  #  limits:
+  #    cpu: 100m
+  #    memory: 128Mi
+  #  requests:
+  #    cpu: 100m
+  #    memory: 128Mi
+  securityContext:
+    runAsNonRoot: false
+    runAsUser: 0
+
+
+# Administrator credentials when not using an existing secret (see below)
+adminUser: admin
+# adminPassword: strongpassword
+
+# Use an existing secret for the admin user.
+admin:
+  ## Name of the secret. Can be templated.
+  existingSecret: ""
+  userKey: admin-user
+  passwordKey: admin-password
+
+## Define command to be executed at startup by grafana container
+## Needed if using `vault-env` to manage secrets (ref: https://banzaicloud.com/blog/inject-secrets-into-pods-vault/)
+## Default is "run.sh" as defined in grafana's Dockerfile
+# command:
+# - "sh"
+# - "/run.sh"
+
+## Extra environment variables that will be pass onto deployment pods
+##
+## to provide grafana with access to CloudWatch on AWS EKS:
+## 1. create an iam role of type "Web identity" with provider oidc.eks.* (note the provider for later)
+## 2. edit the "Trust relationships" of the role, add a line inside the StringEquals clause using the
+## same oidc eks provider as noted before (same as the existing line)
+## also, replace NAMESPACE and prometheus-operator-grafana with the service account namespace and name
+##
+##  "oidc.eks.us-east-1.amazonaws.com/id/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:sub": "system:serviceaccount:NAMESPACE:prometheus-operator-grafana",
+##
+## 3. attach a policy to the role, you can use a built in policy called CloudWatchReadOnlyAccess
+## 4. use the following env: (replace 123456789000 and iam-role-name-here with your aws account number and role name)
+##
+## env:
+##   AWS_ROLE_ARN: arn:aws:iam::123456789000:role/iam-role-name-here
+##   AWS_WEB_IDENTITY_TOKEN_FILE: /var/run/secrets/eks.amazonaws.com/serviceaccount/token
+##   AWS_REGION: us-east-1
+##
+## 5. uncomment the EKS section in extraSecretMounts: below
+## 6. uncomment the annotation section in the serviceAccount: above
+## make sure to replace arn:aws:iam::123456789000:role/iam-role-name-here with your role arn
+
+env: {}
+
+## "valueFrom" environment variable references that will be added to deployment pods. Name is templated.
+## ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#envvarsource-v1-core
+## Renders in container spec as:
+##   env:
+##     ...
+##     - name: <key>
+##       valueFrom:
+##         <value rendered as YAML>
+envValueFrom: {}
+  #  ENV_NAME:
+  #    configMapKeyRef:
+  #      name: configmap-name
+  #      key: value_key
+
+## The name of a secret in the same kubernetes namespace which contain values to be added to the environment
+## This can be useful for auth tokens, etc. Value is templated.
+envFromSecret: ""
+
+## Sensible environment variables that will be rendered as new secret object
+## This can be useful for auth tokens, etc
+envRenderSecret: {}
+
+## The names of secrets in the same kubernetes namespace which contain values to be added to the environment
+## Each entry should contain a name key, and can optionally specify whether the secret must be defined with an optional key.
+## Name is templated.
+envFromSecrets: []
+## - name: secret-name
+##   optional: true
+
+## The names of conifgmaps in the same kubernetes namespace which contain values to be added to the environment
+## Each entry should contain a name key, and can optionally specify whether the configmap must be defined with an optional key.
+## Name is templated.
+## ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#configmapenvsource-v1-core
+envFromConfigMaps: []
+## - name: configmap-name
+##   optional: true
+
+# Inject Kubernetes services as environment variables.
+# See https://kubernetes.io/docs/concepts/services-networking/connect-applications-service/#environment-variables
+enableServiceLinks: true
+
+## Additional grafana server secret mounts
+# Defines additional mounts with secrets. Secrets must be manually created in the namespace.
+extraSecretMounts: []
+  # - name: secret-files
+  #   mountPath: /etc/secrets
+  #   secretName: grafana-secret-files
+  #   readOnly: true
+  #   subPath: ""
+  #
+  # for AWS EKS (cloudwatch) use the following (see also instruction in env: above)
+  # - name: aws-iam-token
+  #   mountPath: /var/run/secrets/eks.amazonaws.com/serviceaccount
+  #   readOnly: true
+  #   projected:
+  #     defaultMode: 420
+  #     sources:
+  #       - serviceAccountToken:
+  #           audience: sts.amazonaws.com
+  #           expirationSeconds: 86400
+  #           path: token
+  #
+  # for CSI e.g. Azure Key Vault use the following
+  # - name: secrets-store-inline
+  #  mountPath: /run/secrets
+  #  readOnly: true
+  #  csi:
+  #    driver: secrets-store.csi.k8s.io
+  #    readOnly: true
+  #    volumeAttributes:
+  #      secretProviderClass: "akv-grafana-spc"
+  #    nodePublishSecretRef:                       # Only required when using service principal mode
+  #       name: grafana-akv-creds                  # Only required when using service principal mode
+
+## Additional grafana server volume mounts
+# Defines additional volume mounts.
+extraVolumeMounts: []
+  # - name: extra-volume-0
+  #   mountPath: /mnt/volume0
+  #   readOnly: true
+  #   existingClaim: volume-claim
+  # - name: extra-volume-1
+  #   mountPath: /mnt/volume1
+  #   readOnly: true
+  #   hostPath: /usr/shared/
+  # - name: grafana-secrets
+  #   csi: true
+  #   data:
+  #     driver: secrets-store.csi.k8s.io
+  #     readOnly: true
+  #     volumeAttributes:
+  #       secretProviderClass: "grafana-env-spc"
+
+## Container Lifecycle Hooks. Execute a specific bash command or make an HTTP request
+lifecycleHooks: {}
+  # postStart:
+  #   exec:
+  #     command: []
+
+## Pass the plugins you want installed as a list.
+##
+plugins: []
+  # - digrich-bubblechart-panel
+  # - grafana-clock-panel
+
+## Configure grafana datasources
+## ref: http://docs.grafana.org/administration/provisioning/#datasources
+##
+datasources: {}
+#  datasources.yaml:
+#    apiVersion: 1
+#    datasources:
+#    - name: Prometheus
+#      type: prometheus
+#      url: http://prometheus-prometheus-server
+#      access: proxy
+#      isDefault: true
+#    - name: CloudWatch
+#      type: cloudwatch
+#      access: proxy
+#      uid: cloudwatch
+#      editable: false
+#      jsonData:
+#        authType: default
+#        defaultRegion: us-east-1
+
+## Configure grafana alerting (can be templated)
+## ref: http://docs.grafana.org/administration/provisioning/#alerting
+##
+alerting: {}
+  # rules.yaml:
+  #   apiVersion: 1
+  #   groups:
+  #     - orgId: 1
+  #       name: '{{ .Chart.Name }}_my_rule_group'
+  #       folder: my_first_folder
+  #       interval: 60s
+  #       rules:
+  #         - uid: my_id_1
+  #           title: my_first_rule
+  #           condition: A
+  #           data:
+  #             - refId: A
+  #               datasourceUid: '-100'
+  #               model:
+  #                 conditions:
+  #                   - evaluator:
+  #                       params:
+  #                         - 3
+  #                       type: gt
+  #                     operator:
+  #                       type: and
+  #                     query:
+  #                       params:
+  #                         - A
+  #                     reducer:
+  #                       type: last
+  #                     type: query
+  #                 datasource:
+  #                   type: __expr__
+  #                   uid: '-100'
+  #                 expression: 1==0
+  #                 intervalMs: 1000
+  #                 maxDataPoints: 43200
+  #                 refId: A
+  #                 type: math
+  #           dashboardUid: my_dashboard
+  #           panelId: 123
+  #           noDataState: Alerting
+  #           for: 60s
+  #           annotations:
+  #             some_key: some_value
+  #           labels:
+  #             team: sre_team_1
+  # contactpoints.yaml:
+  #   apiVersion: 1
+  #   contactPoints:
+  #     - orgId: 1
+  #       name: cp_1
+  #       receivers:
+  #         - uid: first_uid
+  #           type: pagerduty
+  #           settings:
+  #             integrationKey: XXX
+  #             severity: critical
+  #             class: ping failure
+  #             component: Grafana
+  #             group: app-stack
+  #             summary: |
+  #               {{ `{{ include "default.message" . }}` }}
+
+## Configure notifiers
+## ref: http://docs.grafana.org/administration/provisioning/#alert-notification-channels
+##
+notifiers: {}
+#  notifiers.yaml:
+#    notifiers:
+#    - name: email-notifier
+#      type: email
+#      uid: email1
+#      # either:
+#      org_id: 1
+#      # or
+#      org_name: Main Org.
+#      is_default: true
+#      settings:
+#        addresses: an_email_address@example.com
+#    delete_notifiers:
+
+## Configure grafana dashboard providers
+## ref: http://docs.grafana.org/administration/provisioning/#dashboards
+##
+## `path` must be /var/lib/grafana/dashboards/<provider_name>
+##
+dashboardProviders: {}
+#  dashboardproviders.yaml:
+#    apiVersion: 1
+#    providers:
+#    - name: 'default'
+#      orgId: 1
+#      folder: ''
+#      type: file
+#      disableDeletion: false
+#      editable: true
+#      options:
+#        path: /var/lib/grafana/dashboards/default
+
+## Configure grafana dashboard to import
+## NOTE: To use dashboards you must also enable/configure dashboardProviders
+## ref: https://grafana.com/dashboards
+##
+## dashboards per provider, use provider name as key.
+##
+dashboards: {}
+  # default:
+  #   some-dashboard:
+  #     json: |
+  #       $RAW_JSON
+  #   custom-dashboard:
+  #     file: dashboards/custom-dashboard.json
+  #   prometheus-stats:
+  #     gnetId: 2
+  #     revision: 2
+  #     datasource: Prometheus
+  #   local-dashboard:
+  #     url: https://example.com/repository/test.json
+  #     token: ''
+  #   local-dashboard-base64:
+  #     url: https://example.com/repository/test-b64.json
+  #     token: ''
+  #     b64content: true
+  #   local-dashboard-gitlab:
+  #     url: https://example.com/repository/test-gitlab.json
+  #     gitlabToken: ''
+  #   local-dashboard-bitbucket:
+  #     url: https://example.com/repository/test-bitbucket.json
+  #     bearerToken: ''
+
+## Reference to external ConfigMap per provider. Use provider name as key and ConfigMap name as value.
+## A provider dashboards must be defined either by external ConfigMaps or in values.yaml, not in both.
+## ConfigMap data example:
+##
+## data:
+##   example-dashboard.json: |
+##     RAW_JSON
+##
+dashboardsConfigMaps: {}
+#  default: ""
+
+## Grafana's primary configuration
+## NOTE: values in map will be converted to ini format
+## ref: http://docs.grafana.org/installation/configuration/
+##
+grafana.ini:
+  paths:
+    data: /var/lib/grafana/
+    logs: /var/log/grafana
+    plugins: /var/lib/grafana/plugins
+    provisioning: /etc/grafana/provisioning
+  analytics:
+    check_for_updates: true
+  log:
+    mode: console
+  grafana_net:
+    url: https://grafana.net
+  server:
+    domain: "{{ if (and .Values.ingress.enabled .Values.ingress.hosts) }}{{ .Values.ingress.hosts | first }}{{ else }}''{{ end }}"
+## grafana Authentication can be enabled with the following values on grafana.ini
+ # server:
+      # The full public facing url you use in browser, used for redirects and emails
+ #    root_url:
+ # https://grafana.com/docs/grafana/latest/auth/github/#enable-github-in-grafana
+ # auth.github:
+ #    enabled: false
+ #    allow_sign_up: false
+ #    scopes: user:email,read:org
+ #    auth_url: https://github.com/login/oauth/authorize
+ #    token_url: https://github.com/login/oauth/access_token
+ #    api_url: https://api.github.com/user
+ #    team_ids:
+ #    allowed_organizations:
+ #    client_id:
+ #    client_secret:
+## LDAP Authentication can be enabled with the following values on grafana.ini
+## NOTE: Grafana will fail to start if the value for ldap.toml is invalid
+  # auth.ldap:
+  #   enabled: true
+  #   allow_sign_up: true
+  #   config_file: /etc/grafana/ldap.toml
+
+## Grafana's LDAP configuration
+## Templated by the template in _helpers.tpl
+## NOTE: To enable the grafana.ini must be configured with auth.ldap.enabled
+## ref: http://docs.grafana.org/installation/configuration/#auth-ldap
+## ref: http://docs.grafana.org/installation/ldap/#configuration
+ldap:
+  enabled: false
+  # `existingSecret` is a reference to an existing secret containing the ldap configuration
+  # for Grafana in a key `ldap-toml`.
+  existingSecret: ""
+  # `config` is the content of `ldap.toml` that will be stored in the created secret
+  config: ""
+  # config: |-
+  #   verbose_logging = true
+
+  #   [[servers]]
+  #   host = "my-ldap-server"
+  #   port = 636
+  #   use_ssl = true
+  #   start_tls = false
+  #   ssl_skip_verify = false
+  #   bind_dn = "uid=%s,ou=users,dc=myorg,dc=com"
+
+## Grafana's SMTP configuration
+## NOTE: To enable, grafana.ini must be configured with smtp.enabled
+## ref: http://docs.grafana.org/installation/configuration/#smtp
+smtp:
+  # `existingSecret` is a reference to an existing secret containing the smtp configuration
+  # for Grafana.
+  existingSecret: ""
+  userKey: "user"
+  passwordKey: "password"
+
+## Sidecars that collect the configmaps with specified label and stores the included files them into the respective folders
+## Requires at least Grafana 5 to work and can't be used together with parameters dashboardProviders, datasources and dashboards
+sidecar:
+  image:
+    repository: quay.io/kiwigrid/k8s-sidecar
+    tag: 1.19.2
+    sha: ""
+  imagePullPolicy: IfNotPresent
+  resources: {}
+#   limits:
+#     cpu: 100m
+#     memory: 100Mi
+#   requests:
+#     cpu: 50m
+#     memory: 50Mi
+  securityContext: {}
+  # skipTlsVerify Set to true to skip tls verification for kube api calls
+  # skipTlsVerify: true
+  enableUniqueFilenames: false
+  readinessProbe: {}
+  livenessProbe: {}
+  # Log level default for all sidecars. Can be one of: DEBUG, INFO, WARN, ERROR, CRITICAL. Defaults to INFO
+  # logLevel: INFO
+  alerts:
+    enabled: false
+    # Additional environment variables for the alerts sidecar
+    env: {}
+    # Do not reprocess already processed unchanged resources on k8s API reconnect.
+    # ignoreAlreadyProcessed: true
+    # label that the configmaps with alert are marked with
+    label: grafana_alert
+    # value of label that the configmaps with alert are set to
+    labelValue: ""
+    # Log level. Can be one of: DEBUG, INFO, WARN, ERROR, CRITICAL.
+    # logLevel: INFO
+    # If specified, the sidecar will search for alert config-maps inside this namespace.
+    # Otherwise the namespace in which the sidecar is running will be used.
+    # It's also possible to specify ALL to search in all namespaces
+    searchNamespace: null
+    # Method to use to detect ConfigMap changes. With WATCH the sidecar will do a WATCH requests, with SLEEP it will list all ConfigMaps, then sleep for 60 seconds.
+    watchMethod: WATCH
+    # search in configmap, secret or both
+    resource: both
+    # watchServerTimeout: request to the server, asking it to cleanly close the connection after that.
+    # defaults to 60sec; much higher values like 3600 seconds (1h) are feasible for non-Azure K8S
+    # watchServerTimeout: 3600
+    #
+    # watchClientTimeout: is a client-side timeout, configuring your local socket.
+    # If you have a network outage dropping all packets with no RST/FIN,
+    # this is how long your client waits before realizing & dropping the connection.
+    # defaults to 66sec (sic!)
+    # watchClientTimeout: 60
+    #
+    # Endpoint to send request to reload alerts
+    reloadURL: "http://localhost:3000/api/admin/provisioning/alerting/reload"
+    # Absolute path to shell script to execute after a alert got reloaded
+    script: null
+    skipReload: false
+    # Deploy the alert sidecar as an initContainer in addition to a container.
+    # Sets the size limit of the alert sidecar emptyDir volume
+    sizeLimit: {}
+  dashboards:
+    enabled: false
+    # Additional environment variables for the dashboards sidecar
+    env: {}
+    # Do not reprocess already processed unchanged resources on k8s API reconnect.
+    # ignoreAlreadyProcessed: true
+    SCProvider: true
+    # label that the configmaps with dashboards are marked with
+    label: grafana_dashboard
+    # value of label that the configmaps with dashboards are set to
+    labelValue: ""
+    # Log level. Can be one of: DEBUG, INFO, WARN, ERROR, CRITICAL.
+    # logLevel: INFO
+    # folder in the pod that should hold the collected dashboards (unless `defaultFolderName` is set)
+    folder: /tmp/dashboards
+    # The default folder name, it will create a subfolder under the `folder` and put dashboards in there instead
+    defaultFolderName: null
+    # Namespaces list. If specified, the sidecar will search for config-maps/secrets inside these namespaces.
+    # Otherwise the namespace in which the sidecar is running will be used.
+    # It's also possible to specify ALL to search in all namespaces.
+    searchNamespace: null
+    # Method to use to detect ConfigMap changes. With WATCH the sidecar will do a WATCH requests, with SLEEP it will list all ConfigMaps, then sleep for 60 seconds.
+    watchMethod: WATCH
+    # search in configmap, secret or both
+    resource: both
+    # If specified, the sidecar will look for annotation with this name to create folder and put graph here.
+    # You can use this parameter together with `provider.foldersFromFilesStructure`to annotate configmaps and create folder structure.
+    folderAnnotation: null
+    # Absolute path to shell script to execute after a configmap got reloaded
+    script: null
+    # watchServerTimeout: request to the server, asking it to cleanly close the connection after that.
+    # defaults to 60sec; much higher values like 3600 seconds (1h) are feasible for non-Azure K8S
+    # watchServerTimeout: 3600
+    #
+    # watchClientTimeout: is a client-side timeout, configuring your local socket.
+    # If you have a network outage dropping all packets with no RST/FIN,
+    # this is how long your client waits before realizing & dropping the connection.
+    # defaults to 66sec (sic!)
+    # watchClientTimeout: 60
+    #
+    # provider configuration that lets grafana manage the dashboards
+    provider:
+      # name of the provider, should be unique
+      name: sidecarProvider
+      # orgid as configured in grafana
+      orgid: 1
+      # folder in which the dashboards should be imported in grafana
+      folder: ''
+      # type of the provider
+      type: file
+      # disableDelete to activate a import-only behaviour
+      disableDelete: false
+      # allow updating provisioned dashboards from the UI
+      allowUiUpdates: false
+      # allow Grafana to replicate dashboard structure from filesystem
+      foldersFromFilesStructure: false
+    # Additional dashboard sidecar volume mounts
+    extraMounts: []
+    # Sets the size limit of the dashboard sidecar emptyDir volume
+    sizeLimit: {}
+  datasources:
+    enabled: false
+    # Additional environment variables for the datasourcessidecar
+    env: {}
+    # Do not reprocess already processed unchanged resources on k8s API reconnect.
+    # ignoreAlreadyProcessed: true
+    # label that the configmaps with datasources are marked with
+    label: grafana_datasource
+    # value of label that the configmaps with datasources are set to
+    labelValue: ""
+    # Log level. Can be one of: DEBUG, INFO, WARN, ERROR, CRITICAL.
+    # logLevel: INFO
+    # If specified, the sidecar will search for datasource config-maps inside this namespace.
+    # Otherwise the namespace in which the sidecar is running will be used.
+    # It's also possible to specify ALL to search in all namespaces
+    searchNamespace: null
+    # Method to use to detect ConfigMap changes. With WATCH the sidecar will do a WATCH requests, with SLEEP it will list all ConfigMaps, then sleep for 60 seconds.
+    watchMethod: WATCH
+    # search in configmap, secret or both
+    resource: both
+    # watchServerTimeout: request to the server, asking it to cleanly close the connection after that.
+    # defaults to 60sec; much higher values like 3600 seconds (1h) are feasible for non-Azure K8S
+    # watchServerTimeout: 3600
+    #
+    # watchClientTimeout: is a client-side timeout, configuring your local socket.
+    # If you have a network outage dropping all packets with no RST/FIN,
+    # this is how long your client waits before realizing & dropping the connection.
+    # defaults to 66sec (sic!)
+    # watchClientTimeout: 60
+    #
+    # Endpoint to send request to reload datasources
+    reloadURL: "http://localhost:3000/api/admin/provisioning/datasources/reload"
+    # Absolute path to shell script to execute after a datasource got reloaded
+    script: null
+    skipReload: false
+    # Deploy the datasource sidecar as an initContainer in addition to a container.
+    # This is needed if skipReload is true, to load any datasources defined at startup time.
+    initDatasources: false
+    # Sets the size limit of the datasource sidecar emptyDir volume
+    sizeLimit: {}
+  plugins:
+    enabled: false
+    # Additional environment variables for the plugins sidecar
+    env: {}
+    # Do not reprocess already processed unchanged resources on k8s API reconnect.
+    # ignoreAlreadyProcessed: true
+    # label that the configmaps with plugins are marked with
+    label: grafana_plugin
+    # value of label that the configmaps with plugins are set to
+    labelValue: ""
+    # Log level. Can be one of: DEBUG, INFO, WARN, ERROR, CRITICAL.
+    # logLevel: INFO
+    # If specified, the sidecar will search for plugin config-maps inside this namespace.
+    # Otherwise the namespace in which the sidecar is running will be used.
+    # It's also possible to specify ALL to search in all namespaces
+    searchNamespace: null
+    # Method to use to detect ConfigMap changes. With WATCH the sidecar will do a WATCH requests, with SLEEP it will list all ConfigMaps, then sleep for 60 seconds.
+    watchMethod: WATCH
+    # search in configmap, secret or both
+    resource: both
+    # watchServerTimeout: request to the server, asking it to cleanly close the connection after that.
+    # defaults to 60sec; much higher values like 3600 seconds (1h) are feasible for non-Azure K8S
+    # watchServerTimeout: 3600
+    #
+    # watchClientTimeout: is a client-side timeout, configuring your local socket.
+    # If you have a network outage dropping all packets with no RST/FIN,
+    # this is how long your client waits before realizing & dropping the connection.
+    # defaults to 66sec (sic!)
+    # watchClientTimeout: 60
+    #
+    # Endpoint to send request to reload plugins
+    reloadURL: "http://localhost:3000/api/admin/provisioning/plugins/reload"
+    # Absolute path to shell script to execute after a plugin got reloaded
+    script: null
+    skipReload: false
+    # Deploy the datasource sidecar as an initContainer in addition to a container.
+    # This is needed if skipReload is true, to load any plugins defined at startup time.
+    initPlugins: false
+    # Sets the size limit of the plugin sidecar emptyDir volume
+    sizeLimit: {}
+  notifiers:
+    enabled: false
+    # Additional environment variables for the notifierssidecar
+    env: {}
+    # Do not reprocess already processed unchanged resources on k8s API reconnect.
+    # ignoreAlreadyProcessed: true
+    # label that the configmaps with notifiers are marked with
+    label: grafana_notifier
+    # value of label that the configmaps with notifiers are set to
+    labelValue: ""
+    # Log level. Can be one of: DEBUG, INFO, WARN, ERROR, CRITICAL.
+    # logLevel: INFO
+    # If specified, the sidecar will search for notifier config-maps inside this namespace.
+    # Otherwise the namespace in which the sidecar is running will be used.
+    # It's also possible to specify ALL to search in all namespaces
+    searchNamespace: null
+    # Method to use to detect ConfigMap changes. With WATCH the sidecar will do a WATCH requests, with SLEEP it will list all ConfigMaps, then sleep for 60 seconds.
+    watchMethod: WATCH
+    # search in configmap, secret or both
+    resource: both
+    # watchServerTimeout: request to the server, asking it to cleanly close the connection after that.
+    # defaults to 60sec; much higher values like 3600 seconds (1h) are feasible for non-Azure K8S
+    # watchServerTimeout: 3600
+    #
+    # watchClientTimeout: is a client-side timeout, configuring your local socket.
+    # If you have a network outage dropping all packets with no RST/FIN,
+    # this is how long your client waits before realizing & dropping the connection.
+    # defaults to 66sec (sic!)
+    # watchClientTimeout: 60
+    #
+    # Endpoint to send request to reload notifiers
+    reloadURL: "http://localhost:3000/api/admin/provisioning/notifications/reload"
+    # Absolute path to shell script to execute after a notifier got reloaded
+    script: null
+    skipReload: false
+    # Deploy the notifier sidecar as an initContainer in addition to a container.
+    # This is needed if skipReload is true, to load any notifiers defined at startup time.
+    initNotifiers: false
+    # Sets the size limit of the notifier sidecar emptyDir volume
+    sizeLimit: {}
+
+## Override the deployment namespace
+##
+namespaceOverride: ""
+
+## Number of old ReplicaSets to retain
+##
+revisionHistoryLimit: 10
+
+## Add a seperate remote image renderer deployment/service
+imageRenderer:
+  deploymentStrategy: {}
+  # Enable the image-renderer deployment & service
+  enabled: false
+  replicas: 1
+  image:
+    # image-renderer Image repository
+    repository: grafana/grafana-image-renderer
+    # image-renderer Image tag
+    tag: latest
+    # image-renderer Image sha (optional)
+    sha: ""
+    # image-renderer ImagePullPolicy
+    pullPolicy: Always
+  # extra environment variables
+  env:
+    HTTP_HOST: "0.0.0.0"
+    # RENDERING_ARGS: --no-sandbox,--disable-gpu,--window-size=1280x758
+    # RENDERING_MODE: clustered
+    # IGNORE_HTTPS_ERRORS: true
+  # image-renderer deployment serviceAccount
+  serviceAccountName: ""
+  # image-renderer deployment securityContext
+  securityContext: {}
+  # image-renderer deployment container securityContext
+  containerSecurityContext:
+    capabilities:
+      drop: ['ALL']
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+  # image-renderer deployment Host Aliases
+  hostAliases: []
+  # image-renderer deployment priority class
+  priorityClassName: ''
+  service:
+    # Enable the image-renderer service
+    enabled: true
+    # image-renderer service port name
+    portName: 'http'
+    # image-renderer service port used by both service and deployment
+    port: 8081
+    targetPort: 8081
+    # Adds the appProtocol field to the image-renderer service. This allows to work with istio protocol selection. Ex: "http" or "tcp"
+    appProtocol: ""
+  # If https is enabled in Grafana, this needs to be set as 'https' to correctly configure the callback used in Grafana
+  grafanaProtocol: http
+  # In case a sub_path is used this needs to be added to the image renderer callback
+  grafanaSubPath: ""
+  # name of the image-renderer port on the pod
+  podPortName: http
+  # number of image-renderer replica sets to keep
+  revisionHistoryLimit: 10
+  networkPolicy:
+    # Enable a NetworkPolicy to limit inbound traffic to only the created grafana pods
+    limitIngress: true
+    # Enable a NetworkPolicy to limit outbound traffic to only the created grafana pods
+    limitEgress: false
+  resources: {}
+#   limits:
+#     cpu: 100m
+#     memory: 100Mi
+#   requests:
+#     cpu: 50m
+#     memory: 50Mi
+  ## Node labels for pod assignment
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  #
+  nodeSelector: {}
+
+  ## Tolerations for pod assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+
+  ## Affinity for pod assignment (evaluated as template)
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ##
+  affinity: {}
+
+  ## Use an alternate scheduler, e.g. "stork".
+  ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+  ##
+  # schedulerName: "default-scheduler"
+
+networkPolicy:
+  ## @param networkPolicy.enabled Enable creation of NetworkPolicy resources. Only Ingress traffic is filtered for now.
+  ##
+  enabled: false
+  ## @param networkPolicy.allowExternal Don't require client label for connections
+  ## The Policy model to apply. When set to false, only pods with the correct
+  ## client label will have network access to  grafana port defined.
+  ## When true, grafana will accept connections from any source
+  ## (with the correct destination port).
+  ##
+  ingress: true
+  ## @param networkPolicy.ingress When true enables the creation
+  ## an ingress network policy
+  ##
+  allowExternal: true
+  ## @param networkPolicy.explicitNamespacesSelector A Kubernetes LabelSelector to explicitly select namespaces from which traffic could be allowed
+  ## If explicitNamespacesSelector is missing or set to {}, only client Pods that are in the networkPolicy's namespace
+  ## and that match other criteria, the ones that have the good label, can reach the grafana.
+  ## But sometimes, we want the grafana to be accessible to clients from other namespaces, in this case, we can use this
+  ## LabelSelector to select these namespaces, note that the networkPolicy's namespace should also be explicitly added.
+  ##
+  ## Example:
+  ## explicitNamespacesSelector:
+  ##   matchLabels:
+  ##     role: frontend
+  ##   matchExpressions:
+  ##    - {key: role, operator: In, values: [frontend]}
+  ##
+  explicitNamespacesSelector: {}
+  ##
+  ##
+  ##
+  ##
+  ##
+  ##
+  egress:
+    ## @param networkPolicy.egress.enabled When enabled, an egress network policy will be
+    ## created allowing grafana to connect to external data sources from kubernetes cluster.
+    enabled: false
+    ##
+    ## @param networkPolicy.egress.ports Add individual ports to be allowed by the egress
+    ports: []
+    ## Add ports to the egress by specifying - port: <port number>
+    ## E.X.
+    ## ports:
+      ## - port: 80
+      ## - port: 443
+  ##
+  ##
+  ##
+  ##
+  ##
+  ##
+
+# Enable backward compatibility of kubernetes where version below 1.13 doesn't have the enableServiceLinks option
+enableKubeBackwardCompatibility: false
+useStatefulSet: false
+# Create a dynamic manifests via values:
+extraObjects: []
+  # - apiVersion: "kubernetes-client.io/v1"
+  #   kind: ExternalSecret
+  #   metadata:
+  #     name: grafana-secrets
+  #   spec:
+  #     backendType: gcpSecretsManager
+  #     data:
+  #       - key: grafana-admin-password
+  #         name: adminPassword

--- a/helm-charts/dih/charts/service-creator/templates/_helpers.tpl
+++ b/helm-charts/dih/charts/service-creator/templates/_helpers.tpl
@@ -1,0 +1,68 @@
+{{/*
+Expand the name of the chart.
+*/}}
+
+{{- define "service-creator.imagePullSecrets" -}}
+  {{- $pullSecrets := list }}
+  {{- if .Values.global }}
+    {{- range .Values.global.imagePullSecrets -}}
+      {{- $pullSecrets = append $pullSecrets . -}}
+    {{- end -}}
+  {{- end -}}
+  {{- if $pullSecrets }}
+imagePullSecrets:
+    {{- range $pullSecrets }}
+         - name: {{ . }}
+    {{- end }}
+  {{- end }}
+{{- end -}}
+
+{{- define "service-creator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "service-creator.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "service-creator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "service-creator.labels" -}}
+helm.sh/chart: {{ include "service-creator.chart" . }}
+{{ include "service-creator.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+
+{{/*
+Selector labels
+*/}}
+{{- define "service-creator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "service-creator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/helm-charts/dih/charts/service-operator/templates/qsvc-delete-hook.yaml
+++ b/helm-charts/dih/charts/service-operator/templates/qsvc-delete-hook.yaml
@@ -1,0 +1,59 @@
+{{- if .Values.qsvcAutoCleanup.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-qsvc-deleter-role
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups: [ "gigaspaces.com" ]
+    resources: [ "queryservices" ]
+    verbs: [ "get", "list", "delete","patch" ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-qsvc-deleter-rolebinding
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-qsvc-deleter-role
+subjects:
+  - kind: Group
+    name: "system:serviceaccounts:{{ .Release.Namespace }}"
+    namespace: {{ .Release.Namespace }}
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-qsvc-deleter-sa
+  namespace: {{ .Release.Namespace }}
+---
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-qsvc-deleter-job
+  namespace:  {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": "pre-delete"
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": "hook-succeeded,before-hook-creation"
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: pre-delete-qsvc-job
+          image: "harbor.hq.bbwcorp.com/bbw_omni_channel_it/giga/bitnami/kubectl"
+          command: [ "kubectl" ]
+          args:
+            - "delete"
+            - "qsvc"
+            - "--all"
+            - "--wait=false"
+      serviceAccountName: {{ .Release.Name }}-qsvc-deleter-sa
+      securityContext:
+        runAsUser: 0
+{{- end }}

--- a/helm-charts/dih/charts/xap-dgw/templates/_helpers.tpl
+++ b/helm-charts/dih/charts/xap-dgw/templates/_helpers.tpl
@@ -1,0 +1,44 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "xap-dgw.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "xap-dgw.imagePullSecrets" -}}
+  {{- $pullSecrets := list }}
+
+  {{- if .Values.global }}
+    {{- range .Values.global.imagePullSecrets -}}
+      {{- $pullSecrets = append $pullSecrets . -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- if (not (empty $pullSecrets)) }}
+imagePullSecrets:
+    {{- range $pullSecrets }}
+  - name: {{ . }}
+    {{- end }}
+  {{- end }}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "xap-dgw.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+    {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+    {{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "xap-dgw.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/helm-charts/dih/charts/xap-dgw/values.yaml
+++ b/helm-charts/dih/charts/xap-dgw/values.yaml
@@ -1,0 +1,47 @@
+# Default values for xap-dgw
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+fullnameOverride: xap-dgw
+image:
+  repository: "harbor.hq.bbwcorp.com/bbw_omni_channel_it/giga/gigaspaces/smart-cache-enterprise"
+  tag: 16.4.2
+  pullPolicy: IfNotPresent #Always
+terminationGracePeriodSeconds: 30
+# license: Define the GigaSpaces XAP licence key.
+license: tryme
+# properties: Used to override the pu.xml properties that are defined as placeholders, receives string such as: memoryThreshold=7g (see documentation)
+properties:
+nodeSelector:
+  enabled: false
+  selector:
+# instances: Define the number of instances (not applicable for `partitioned` schema)
+instances: 1
+# java: Define the Java options for each processing unit instance.
+java:
+  # heap: Define the size of the on-heap memory for each processing unit instance as either a percentage or an absolute value.
+  heap: limit-150Mi
+  # options: Configure additional Java options for each processing unit instance.
+  options:
+# resources: Configure the processing unit instance resources.
+resources:
+  # Best practice is do not specify default resources, so the user can configure independently.
+  # This can be especially risky when the chart is run on an environment with limited
+  # resources, such as a minikube. If you still want to configure specific resources, adjust the values as necessary.
+  limits:
+    memory: 400Mi
+env:
+# manager: Used when you install the Platform Manager separately; insert the Platform Manager release name here.
+manager:
+  name: xap-manager
+  ports:
+    api: 8090
+  # discoveryTimeoutSeconds: Define the length of the timeout for checking if the Platform Manager is available.
+  # If the timeout expires and the Platform Manager is still unavailable, the init pod will restart.
+  discoveryTimeoutSeconds: 60
+# When enabled, mount metrics configMap for metrics reported by Gigaspaces components.
+metrics:
+  enabled: false
+# When enabled, will attach a volume for the tierd-storage.
+persistence:
+  enabled: false

--- a/helm-charts/dih/charts/xap-operator/templates/deployment.yaml
+++ b/helm-charts/dih/charts/xap-operator/templates/deployment.yaml
@@ -1,0 +1,202 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: xap-operator
+  namespace:  {{ .Release.Namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: xap-operator
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        name: xap-operator
+        release: {{ .Release.Name }}
+    spec:
+      {{- include "xap.operator.imagePullSecrets" . | nindent 6 }}
+      initContainers:
+        - name: create-keystore
+          image: harbor.hq.bbwcorp.com/bbw_omni_channel_it/giga/alpine/openssl
+          command: ['sh', '-c', 'if [ ! -f /ssl/tls.crt ]; then cp /app/webhookkey.p12 /keystore/webhookkey.p12; else openssl pkcs12 -password pass:{{ .Values.webhook.keyStorePassword }} -export -in /ssl/tls.crt -inkey /ssl/tls.key -out /keystore/webhookkey.p12 -certfile /ssl/ca.crt; fi']
+          volumeMounts:
+            - name: default-keystore
+              mountPath: /app/webhookkey.p12
+              subPath: webhookkey.p12
+            {{- if not .Values.webhook.ca }}
+            - name: ssl
+              mountPath: /ssl
+              readOnly: true
+            {{- end }}
+            - name: keystore
+              mountPath: /keystore
+        {{- if .Values.delay }}
+        - name: wait-for-master-before-starup
+          image: "{{ .Values.image.init.repository }}:{{ .Values.image.init.tag }}"
+          # wait for the manager to be available. wait additional time for HA to get zookeeper quorum
+          command: [ "sh", "-c", "until nc -z xap-manager-service 8090 > /dev/null; do echo Waiting for master.; sleep 5; done; sleep 100;" ]
+        {{- end }}
+      containers:
+        - image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          volumeMounts:
+            {{- if .Values.keystore.enabled }}
+            - name: tls
+              mountPath: /opt/gigaspaces/config/keystore/
+              readOnly: true
+            {{- end }}
+            {{- if .Values.global.security.enabled }}
+            - name: private-key
+              mountPath: {{ .Values.security.privateKeyPath }}
+              subPath: key
+              readOnly: true
+            {{- end }}
+            {{- if not .Values.webhook.ca }}
+            - name: ssl
+              mountPath: /opt/gigaspaces/config/ssl/
+              readOnly: true
+            {{- end }}
+            - name: keystore
+              mountPath: /opt/gigaspaces/config/keystore/
+          imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+          name: xap-operator
+          env:
+            - name: GS_LICENSE
+              value: "{{ .Values.license}}"
+            - name: PRE_UNDEPLOY_TIMEOUT
+              value: "15000"
+            - name: PRE_DEPLOYMENT_TIMEOUT
+              value: "60000"
+            - name: UPDATING_TIMEOUT
+              value: "60000"
+            - name: DEPLOYMENT_STARTED_TIMEOUT
+              value: "240000"
+            - name: PU_READINESS_CHECK_DELAY
+              value: "10"
+            - name: MANAGER_BASE_URL
+              value: "http://{{ .Values.manager.name }}-service:{{ .Values.manager.port }}"
+            - name: NAMESPACE
+              value: {{ .Release.Namespace }}
+            - name: RELEASE_NAME
+              value: {{ .Release.Name }}
+            - name: MANAGER_NAME
+              value: {{ .Values.manager.name }}
+            - name: ANTIAFFINITY_TOPOLOGY
+              value: {{ .Values.antiAffinity.topology | default "topology.kubernetes.io/zone" }}
+            {{- if .Values.keystore.enabled }}
+            - name: KEY_STORE_TYPE
+              value: {{ .Values.keystore.keystoreType}}
+            - name: KEY_STORE_FILE
+              value: {{ .Values.keystore.fileName}}
+            - name: KEY_STORE_PSWD
+              value: {{ .Values.keystore.password}}
+            {{- end }}
+            {{- if .Values.global.security.enabled }}
+            - name: SECURED
+              value: "{{ .Values.global.security.enabled }}"
+            - name: KID
+              value: {{ .Values.security.kid }}
+            - name: SECURITY_CONFIG
+              value: {{ .Values.security.permissionsConfigMap }}
+            - name: SECURITY_PRIVATE_KEY_PATH
+              value: {{ .Values.security.privateKeyPath }}
+            - name: SECURITY_BASE_URL
+              value: "http://{{ .Values.global.xap.security.service.name }}-service:{{ .Values.global.xap.security.service.port }}"
+          {{- end }}
+          envFrom:
+            {{- if .Values.global.security.enabled }}
+            - configMapRef:
+                name: "{{ .Values.security.permissionsConfigMap }}"
+          {{- end}}
+          ports:
+            - containerPort: 8443
+              name: webhook-api
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+      {{- toYaml .Values.nodeSelector | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: tls
+          secret:
+            secretName: {{ .Values.keystore.secretName}}
+        - name: default-keystore
+          configMap:
+            name: default-keystore
+        {{- if not .Values.webhook.ca }}
+        - name: ssl
+          secret:
+            secretName: {{ .Release.Name }}-certificate
+        {{- end }}
+        - name: keystore
+          emptyDir: {}
+        - name: private-key
+          secret:
+            secretName: {{ .Values.security.privateKeySecretName }}
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: default-{{ .Release.Namespace }}
+  namespace:  {{ .Release.Namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace:  {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+  {{- if .Values.autoCleanup.enabled }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: xap-purge-pu-job
+  namespace:  {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": "pre-delete"
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": "hook-succeeded,before-hook-creation"
+spec:
+  template:
+    spec:
+      containers:
+        - name: xap-purge-resources
+          # having seperate image for job but same(!!!) image tag as the operator has
+          image: "{{ .Values.autoCleanup.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+          env:
+            - name: PURGE_TIMEOUT
+              value: "{{ .Values.autoCleanup.timeoutSeconds }}"
+            - name: NAMESPACE
+              value: {{ .Release.Namespace }}
+          resources: {{ toYaml .Values.resources | nindent 12 }}
+      restartPolicy: OnFailure
+      terminationGracePeriodSeconds: 0
+  backoffLimit: 3
+  {{- end }}
+---
+---
+  {{- if .Values.global.security.enabled }}
+#operator default private key - should be changed to client's key
+apiVersion: v1
+kind: Secret
+metadata:
+  name: service-account-private-key
+type: Opaque
+data:
+  key: |
+    LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2Z0lCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktnd2dnU2tBZ0VBQW9JQkFRRFJZdEJFdWFhZW83NTMKYndLSm9INmtyNk5rdVZCRHBpdFBkZ2JUK1hOODlqdGFYcUNWNUZyN1JQTmlzSHl4VmJFWUhXZndnbE82cGZIQgpiUGJsaUVTNW5iSHZGNVlhYWNFWXo5cTVXaExuSGViS2JHMHRZd25IUkkyaHdxSXhtZU1jMmJuL2JxaVQ3OUdHClNOLzUzaXhyRmdRU3RGSjc1cVVKU2RGZThMVzZWWlJYbEFPenZUNHg2OWdialRHY2NEWHk0V2RaZERtVTVxcjgKdDN6bVptVmRkY3BhY0ZkZDcyaDIyOE5RaHNlcXFteFVvckI3VG9FU0laTVZzYnhmZVBrSytHVHhHRHRKMmF6MQpNSndSemR4QW5Bb3NmbXRqa0g3dDZYVkQ2b1Z4YVkwYUpXWHliZFJrNjlDa2didzdERGJMeFNmSFlRZEFDRXpzCmRaa0lDZy9QQWdNQkFBRUNnZ0VBVDRtb3NhS1FMNHpsNmpxS0RUdWhQKy9VTW92T2VKUWp1YUNOQVhLdHN4ZFoKL244Wm96YkdkTktCWGNqSzVSWTNHb0Q1SGJ4MEQ5Ky9rUWxTVkdqS0tuUkR4aDRBai9JQ1B1bWVIWENnNDVoUgpOaTJ2MzJEU3N4WlFjdFViaFpuK1V0UkdPa2lQMHZwemJmNDZ6cERkOEtQQlVsV2JTNk9XcDR1WjgrV2VNclJsCk8zWWpJaUVaT1BPUmU1endyeFVvUU5xQVJwd204RnBJREdNRUVHcTFLSU9QTTM4OXVZaG14ZWp4eXJ0bW9neG0KSStGSzdxNmRrRVVoU2JoVnlhdGxEWG82VjZZN2ZxRTkrSUtWRnJIbnc1cDR2N0wwNXc4RVdwcDUzVWd2UVVFbQpxOWpaclBkWUZoaTlTaVpIalVGQ243NWkzLy9Pa2JBK2g0bzlQM1ROU1FLQmdRRDRaVUEvNlpNY042V2lhTlBQCjJTWHh2bkVBTG1JRmpScnJDRWIwaThOMFBISmdnazhDanFzN1V6WWUxeXBMTCtPbHBuakYzQW14ZFpmQkRGOTEKeXFMTmpCZTRwd3huSE9jSXdKNnN6K3ZQWkRWMlgrWnYxRVVGQ295SE9RUzVIU1RRNmlSeW0rc1hCaU9IYStyawpnSXJQZTd6UFI4NGVieHhXZ3hMYVBhTXJLd0tCZ1FEWHk5VmJrNzVaMnlEdHdVMGw5S0ZuR0hpb3VQR2hlQ0NQCnV1ZUxybTBmd3MwNVZuN3FrNHBOOWNHTjJyaDBrVFFxcm5VZWtCTXI1MzdrMnk5Qm1CQkxHT0F6cXkrQ2p5K1MKekdmcjd0dEtHalhrb2pMNW1IS2NGV204NXRXQkNwc1lGcUUxYTJxTm1hME5Xbnl2Y1p3aGZWNys2dUhZL3RhTQordmViWGtETDdRS0JnRlJnWUlEVllRbDJ4YWJ6b08rN3ZhM3VtUWdNdVhOVlNVMkpWRUVCc1BVdEMxVkpMbm1aCjZRU1A4WlJzVm91UHl1NmNLKzVhSGxqUHJ5citmdmJPVEpzeCtXVGFLZFprOVAzK0lHaG5nSnpFVjN6TWVzU0cKQUtRRHYxUzN3NmoyQTJtTC83R0cwVWJTNlFLNVgrTWEzd3czNWgwck1STVpmekRMK1gxMDdwWmRBb0dCQU5MQworZmNmTFdLRmFudkx0NVhDZjRFNW5WN3NndEs1aU5QWU1CMTBsby9XcXFtOW1PZHlnam55Tk1CZlJwaFMyU2gyCmkxejJTa012TGZoSE9yaE4xRndFUjdVdkZJL25XUWQvTEdCNlFTTDJ4bnd2RHFwSUFtZi9ZZTVsWlZGTEVuOU0KV3RiWnVvL2g3K3FDM2hSY1dhazcwWFFYNDgwVDJHaUpGUnhoeWRkaEFvR0JBT1FIQTZEN1pxcjc3S25rQ2lmVwo0OTl2RGxtKyt3a041THZGc25wZUszNFdyY3dXc1o1YjFTZ3EvVm1lbVdKdDFvWXBCYXFLa1lMQ0dBSHdvc2xPCmg2Q1EwaGVpdy9SUEErcUhvaWdUZVNLbFQxU0NuOEQ5ZUxPT2VDdURsNkIwdzY5U2VBYU1uRjV0dEtpSFFqWEcKbW0zYmFaWmFleWpaSHlqWVpaYTNSTE0zCi0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K
+  {{- end }}
+---
+  {{- if .Values.global.security.enabled }}
+#operator security permissions config map
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: operator-security-map
+data:
+  permissions: |
+    GridPrivilege PROVISION_PU
+  {{- end }}

--- a/helm-charts/dih/charts/xap-operator/values.yaml
+++ b/helm-charts/dih/charts/xap-operator/values.yaml
@@ -1,0 +1,73 @@
+# Default values for xap-operator.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+global:
+  security:
+    enabled: true
+  xap:
+    security:
+      service:
+        name: xap-security
+        port: 9000
+nameOverride: xap-operator
+image:
+  repository: gigaspaces/cache-operator
+  tag: 16.4.2
+  pullPolicy: IfNotPresent
+  init:
+    repository: "harbor.hq.bbwcorp.com/bbw_omni_channel_it/giga/busybox"
+    tag: 1.36.0
+terminationGracePeriodSeconds: 30
+delay: false
+podAnnotations: {}
+podSecurityContext: {}
+# fsGroup: 2000
+
+securityContext: {}
+# capabilities:
+#   drop:
+#   - ALL
+# readOnlyRootFilesystem: true
+# runAsNonRoot: true
+# runAsUser: 1000
+
+license: tryme
+manager:
+  name: xap-manager
+  port: 8090
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 2
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+nodeSelector: {}
+tolerations: []
+affinity: {}
+antiAffinity:
+  #  default "topology.kubernetes.io/zone"
+  topology:
+keystore:
+  enabled: false
+  secretName: nameOfSecret
+  password: nameOfLiteralItemInSecretRepresentsPassword
+  fileName: nameOfFileItemInSecretRepresentsKeystore
+  keystoreType: PKCS12
+autoCleanup:
+  enabled: true
+  #  default timeout: 30s
+  timeoutSeconds: 30
+  image:
+    repository: gigaspaces/cache-operator-purge-job
+resources: {}
+webhook:
+  ca: "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURRakNDQWlxZ0F3SUJBZ0lKQU9HRDFrQ1NIc0ZyTUEwR0NTcUdTSWIzRFFFQkJRVUFNQzh4TFRBckJnTlZCQU1NSkVGa2JXbHpjMmx2YmlCRGIyNTBjbTlzYkdWeUlGZGxZbWh2YjJzZ1JHVnRieUJEUVRBZUZ3MHlNakE0TURNeE5USTVNVEphRncwek5qQTBNVEV4TlRJNU1USmFNQ294S0RBbUJnTlZCQU1NSDNkbFltaHZiMnN0YzJWeWRtVnlMbmRsWW1odmIyc3RaR1Z0Ynk1emRtTXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCRHdBd2dnRUtBb0lCQVFDcDVqNmhoWUtUOFFBZ21VaFQrclBRSG95bGU4czlJRUdKN1BvZWpaMzhKeGVQRGI1Ym1nTWg1cG5yd1ZGWVZHK2xYTlpvY05zeWtlb3hZTkFJTG1iVXRMSTl1QjJwWEJVRWpJWUVmZUw1VGZkblFaazRqQzJtK21jQmh3Y3UrUlJzVXRSMGx0emp1RE9rY2V4M0JqakxZejN3dlkyOGZaT1JjcUtJM0tvZW03ck5IbVJ1TGdVNGNRcWZFdnB6T0Y3MmJ2Wm1QWEdWTWhXY1hwa1VWaFJyQm9oM0hjMnpJSmY0SktyMXNOQlhtYjBSRjVTN3l3STFUMkYwMjludEZOM1dNWjVaWXVyZ0ZsbnVxeW5DQk1NL2hJVnZhVVJrd282YUswU1k1aVRRWmlNMFJUd3J0TW5OS2xkaWJPSkhPZ1BrZFZDU0lkNUdZaGJaOU9QOEN1RGZBZ01CQUFHalpqQmtNQWtHQTFVZEV3UUNNQUF3Q3dZRFZSMFBCQVFEQWdYZ01CMEdBMVVkSlFRV01CUUdDQ3NHQVFVRkJ3TUNCZ2dyQmdFRkJRY0RBVEFyQmdOVkhSRUVKREFpZ2hwM1pXSm9iMjlyTFhObGNuWmxjaTVrWldaaGRXeDBMbk4yWTRjRXdLaVpNakFOQmdrcWhraUc5dzBCQVFVRkFBT0NBUUVBYlpoSnBJVVpINU1uTXoyb1dEekNiK2JOMEhBK2RyRDFGclFHK1NQc0gvNVVsU3lLaGxRb0VOQ1drT3d1YkJYUGNPL2lVSTcvNWc0aEV5VVFVdWQ2WXMxY1Q2a0p0Q2lPV2hDWXl0elVVYlVSNy9EODRmZDM2Ym53M3MzOVNoeTMyUzFOWXRBVUl6cU1Kak92MVBQWXJyNXVSM2FuenVlVEJiNlU0cmo1enhhRFRBR0dpL1MvMkNta0Y3RUxmdXo1Q2lFTmZVSTFtMzY2NG9ybC9FbDV6RUVNWVF1Ulg0ZFh4YVRtODh2MVZTYy92REFxY1VXZTFvelRXR3ZBRlpKcGtrZmFwZ2VDbG9KSDhDZlpPKzExU3NQTjhkZ1dIUE9CY3pobERlY3FLbTNub21yQ0hUbE1yaDBKUEJMRFMrVm5XdEl2dzB1dWVlc3hJTXNKUTZUWWNnPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo="
+  port: 8443
+  keyStore: "classpath:keystore/webhookkey.p12"
+  keyStorePassword: "password"
+  keyStoreType: "PKCS12"
+security:
+  kid: common
+  permissionsConfigMap: operator-security-map
+  privateKeySecretName: service-account-private-key
+  privateKeyPath: /opt/gigaspaces/config/security/key

--- a/helm-charts/dih/templates/post-delete-hook.yaml
+++ b/helm-charts/dih/templates/post-delete-hook.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-pvc-deleter-role
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "persistentvolumeclaims" ]
+    verbs: [ "get", "list", "delete", "deletecollection" ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-pvc-deleter-rolebinding
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-pvc-deleter-role
+subjects:
+  - kind: Group
+    name: "system:serviceaccounts:{{ .Release.Namespace }}"
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-pvc-deleter-sa
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-pvc-deleter-job
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": hook-succeeded
+    "app.kubernetes.io/instance": {{ .Release.Name }}
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: post-delete-job
+          image: "harbor.hq.bbwcorp.com/bbw_omni_channel_it/giga/bitnami/kubectl"
+          command: [ "kubectl" ]
+          args:
+            - "delete"
+            - "pvc"
+            - "--wait=false"
+            - "-l"
+            - "app.kubernetes.io/instance={{ .Release.Name }}"
+      serviceAccountName: {{ .Release.Name }}-pvc-deleter-sa
+      securityContext:
+        runAsUser: 0

--- a/helm-charts/xap-pu/templates/_helpers.tpl
+++ b/helm-charts/xap-pu/templates/_helpers.tpl
@@ -1,0 +1,44 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "xap-pu.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "xap-pu.imagePullSecrets" -}}
+  {{- $pullSecrets := list }}
+
+  {{- if .Values.global }}
+    {{- range .Values.global.imagePullSecrets -}}
+      {{- $pullSecrets = append $pullSecrets . -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- if (not (empty $pullSecrets)) }}
+imagePullSecrets:
+    {{- range $pullSecrets }}
+  - name: {{ . }}
+    {{- end }}
+  {{- end }}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "xap-pu.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+    {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+    {{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "xap-pu.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/helm-charts/xap-pu/templates/pu-statefulset.yaml
+++ b/helm-charts/xap-pu/templates/pu-statefulset.yaml
@@ -1,0 +1,51 @@
+apiVersion: gigaspaces.com/v1
+kind: ProcessingUnit
+metadata:
+  name: {{ template "xap-pu.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    release: {{ .Release.Name }}
+spec:
+  productType: xap
+  antiAffinity: {{  .Values.antiAffinity.enabled }}
+  env: {{ toYaml .Values.env | nindent 4 }}
+  envFrom: {{ toYaml .Values.envFrom | nindent 4 }}
+  ha: {{  .Values.ha }}
+  {{- include "xap-pu.imagePullSecrets" . | nindent 2 }}
+  image:
+    pullPolicy: "{{  .Values.image.pullPolicy }}"
+    repository: "{{  .Values.image.repository }}"
+    tag: "{{  .Values.image.tag }}"
+  instances: {{  .Values.instances }}
+  javaHeap: {{  .Values.java.heap }}
+  {{- if .Values.java.options }}
+  javaOptions: {{ .Values.java.options }}
+  {{- end }}
+  license: {{  .Values.license }}
+  livenessProbe: {{ toYaml  .Values.livenessProbe | nindent 4 }}
+  securityService: {{ toYaml .Values.securityService | nindent 4 }}
+  manager: {{ toYaml .Values.manager | nindent 4 }}
+  multiCast: false
+  {{- if  .Values.nodeSelector.enabled }}
+  nodeSelector:
+    enabled: {{ .Values.nodeSelector.enabled }}
+    selector: {{ .Values.nodeSelector.selector }}
+  {{- end }}
+  partitions: {{  .Values.partitions }}
+  properties: {{ toYaml .Values.properties | nindent 4 }}
+  propertiesFrom: {{ toYaml .Values.propertiesFrom | nindent 4 }}
+  readinessProbe: {{ toYaml  .Values.readinessProbe | nindent 4 }}
+  resourceUrl: {{ .Values.resourceUrl }}
+  resources:
+    limits:
+      {{- if  .Values.resources.limits.cpu }}
+      cpu: {{  .Values.resources.limits.cpu }}
+      {{- end }}
+      memory: {{  .Values.resources.limits.memory}}
+    requests: null
+  persistence: {{ toYaml  .Values.persistence | nindent 4 }}
+  volumeMounts: {{ toYaml  .Values.volumeMounts | nindent 4 }}
+  {{- if  .Values.statefulSetExtension.enabled }}
+  statefulSetExtension:
+    spec: {{ toYaml  .Values.statefulSetExtension.spec | nindent 6 }}
+  {{- end }}

--- a/helm-charts/xap-pu/values.yaml
+++ b/helm-charts/xap-pu/values.yaml
@@ -1,0 +1,98 @@
+# Default values for xap-pu.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+global:
+  imagePullSecrets:
+nameOverride: xap-pu
+image:
+  repository: gigaspaces/smart-cache-enterprise
+  tag: 16.4.2
+  pullPolicy: IfNotPresent #Always
+terminationGracePeriodSeconds: 30
+# imagePullSecrets: Define an array of secret's names to pull image
+# imagePullSecrets:
+# license: Define the GigaSpaces XAP licence key.
+license: tryme
+# resource: Define the URL of Processing Unit JAR file.
+resourceUrl:
+# properties: Used to override the pu.xml properties that are defined as placeholders, receives string such as: memoryThreshold=7g (see documentation)
+properties:
+propertiesFrom:
+# schema: Define the cluster schema (optional)
+# valid values: partitioned, sync_replicated ,async_replicated
+# If the schema is not defined, the default value is based on the partitions property (see below).
+schema:
+# partitions: Define the number of partitions in the cluster.
+partitions: 1
+# HA: Define whether the cluster should be highly available.
+# Set the anti-affinity value to enabled=true to ensure pod distribution across different nodes.
+ha:
+# Define the pod anti-affinity
+antiAffinity:
+  # enabled: Define whether Pod anti-affinity is enabled.
+  enabled: false
+# Define the pod liveness probe
+# See structure: [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#Probe) for details.
+livenessProbe:
+# Define the pod readinessProbe probe
+# See structure: [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#Probe) for details.
+readinessProbe:
+# Add custom mounting of a volumes within a base container
+# See structure: [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1 - volumeMounts) for details.
+volumeMounts:
+nodeSelector:
+  enabled: false
+  selector:
+# instances: Define the number of instances (not applicable for `partitioned` schema)
+instances:
+# java: Define the Java options for each processing unit instance.
+java:
+  # heap: Define the size of the on-heap memory for each processing unit instance as either a percentage or an absolute value.
+  heap: limit-150Mi
+  # options: Configure additional Java options for each processing unit instance.
+  options:
+# resources: Configure the processing unit instance resources.
+resources:
+  # Best practice is do not specify default resources, so the user can configure independently.
+  # This can be especially risky when the chart is run on an environment with limited
+  # resources, such as a minikube. If you still want to configure specific resources, adjust the values as necessary.
+  limits:
+    memory: 4Gi
+env:
+envFrom:
+# manager: Used when you install the Platform Manager separately; insert the Platform Manager release name here.
+manager:
+  name: xap-manager
+  ports:
+    api: 8090
+  # discoveryTimeoutSeconds: Define the length of the timeout for checking if the Platform Manager is available.
+  # If the timeout expires and the Platform Manager is still unavailable, the init pod will restart.
+  discoveryTimeoutSeconds: 60
+securityService:
+# When enabled, mount metrics configMap for metrics reported by Gigaspaces components.
+metrics:
+  enabled: false
+# When enabled, will attach a volume for the tierd-storage.
+persistence:
+  enabled: false
+  storageClassName:
+  # default: ReadWriteOnce
+  accessMode:
+  # default: 10Gi
+  size:
+# Enable override of statefulset
+# Statefulset overrides - can be used to add additional setting for the stateful set that the Processing Unit is creating.
+statefulSetExtension:
+  enabled: false
+  spec:
+    template:
+      metadata:
+        annotations:
+        labels:
+        finalizers:
+      spec:
+        initContainers:
+        containers:
+        volumes:
+        securityContext:
+        serviceAccountName:

--- a/helm-override-values/override_repo.yaml
+++ b/helm-override-values/override_repo.yaml
@@ -1,4 +1,6 @@
 global:
+  imagePullSecrets:
+    - myregistrysecret
   security:
     enabled: false
     # global (admin) password is expected to be given in installation
@@ -59,21 +61,23 @@ influxdb:
 grafana:
   image:
     repository: harbor.hq.bbwcorp.com/bbw_omni_channel_it/giga/grafana
+    pullsecrets: myregistrysecret
   sidecar:
     repository: harbor.hq.bbwcorp.com/bbw_omni_channel_it/giga/k8s-sidecar
 
 #gigaspaces/mcs-service-operator:1.0.13
 service-operator:
-  enabled: false
+  enabled: true
   image:
     repository: harbor.hq.bbwcorp.com/bbw_omni_channel_it/giga/mcs-service-operator
   operatorConfig:
-  image: harbor.hq.bbwcorp.com/bbw_omni_channel_it/giga/mcs-query-service:1.0.14
+  image: harbor.hq.bbwcorp.com/bbw_omni_channel_it/giga/mcs-query-service
+  tag: 1.0.21
   # "bitnami/kubectl" - service-operator - currently cannot be overridden 
 
 #gigaspaces/mcs-service-creator:1.0.13
 service-creator:
-  enabled: false
+  enabled: true
   image:
     repository: harbor.hq.bbwcorp.com/bbw_omni_channel_it/giga/mcs-service-creator
     tag: 1.0.21 # this image has been provided by Sapir

--- a/helm-override-values/pu-overrides.yaml
+++ b/helm-override-values/pu-overrides.yaml
@@ -1,0 +1,13 @@
+image:
+  repository: "harbor.hq.bbwcorp.com/bbw_omni_channel_it/giga/gigaspaces/smart-cache-enterprise"
+schema: partitioned
+partitions: 2
+ha: true
+resources:
+  limits:
+    memory: 4Gi
+
+global:
+  imagePullSecrets:
+   - myregistrysecret
+


### PR DESCRIPTION
Update xap-pu chart to include pull secrets 

Service creator and operator - default tag is 1.0.13, updated to 1.0.21
 
Grafana not working - 1. hardcode securityContext: {} in dih/charts/grafana/values.yaml, comment out section that sets user to id 472. 2. Uncomment the pullSecrets in dih/charts/grafana/values.yaml, add pullSecrets to override_repo.yaml

Previous dih updates - makes use override_repo.yaml 1. Include image information that must be in configured in charts (we don't have placeholders for these in the charts; i.e; busybox, aplpine/openssl) 2. Pull secrets (xap-dgw, service creator)